### PR TITLE
Add basic Java 9 JPMS support

### DIFF
--- a/example/lwjgl3-opengl/src/main/java/com/labymedia/ultralight/lwjgl3/opengl/listener/ExampleLoadListener.java
+++ b/example/lwjgl3-opengl/src/main/java/com/labymedia/ultralight/lwjgl3/opengl/listener/ExampleLoadListener.java
@@ -19,11 +19,11 @@
 
 package com.labymedia.ultralight.lwjgl3.opengl.listener;
 
-import com.labymedia.ultralight.Databind;
-import com.labymedia.ultralight.DatabindConfiguration;
-import com.labymedia.ultralight.DatabindJavascriptClass;
 import com.labymedia.ultralight.UltralightView;
-import com.labymedia.ultralight.api.JavaAPI;
+import com.labymedia.ultralight.databind.Databind;
+import com.labymedia.ultralight.databind.DatabindConfiguration;
+import com.labymedia.ultralight.databind.DatabindJavascriptClass;
+import com.labymedia.ultralight.databind.api.JavaAPI;
 import com.labymedia.ultralight.javascript.*;
 import com.labymedia.ultralight.lwjgl3.opengl.support.ViewContextProvider;
 import com.labymedia.ultralight.plugin.loading.UltralightLoadListener;

--- a/example/lwjgl3-opengl/src/main/java/com/labymedia/ultralight/lwjgl3/opengl/support/ViewContextProvider.java
+++ b/example/lwjgl3-opengl/src/main/java/com/labymedia/ultralight/lwjgl3/opengl/support/ViewContextProvider.java
@@ -20,8 +20,8 @@
 package com.labymedia.ultralight.lwjgl3.opengl.support;
 
 import com.labymedia.ultralight.UltralightView;
-import com.labymedia.ultralight.context.ContextProviderFactory;
-import com.labymedia.ultralight.context.ContextProvider;
+import com.labymedia.ultralight.databind.context.ContextProvider;
+import com.labymedia.ultralight.databind.context.ContextProviderFactory;
 import com.labymedia.ultralight.javascript.JavascriptContextLock;
 import com.labymedia.ultralight.javascript.JavascriptValue;
 

--- a/ultralight-java-base/build.gradle
+++ b/ultralight-java-base/build.gradle
@@ -6,11 +6,11 @@ plugins {
 group 'com.labymedia'
 
 jar {
-	manifest {
-		attributes(
-			'Automatic-Module-Name': 'com.labymedia.ultralight'
-		)
-	}
+    manifest {
+        attributes(
+            'Automatic-Module-Name': 'com.labymedia.ultralight'
+        )
+    }
 }
 
 processResources {

--- a/ultralight-java-base/build.gradle
+++ b/ultralight-java-base/build.gradle
@@ -5,6 +5,14 @@ plugins {
 
 group 'com.labymedia'
 
+jar {
+	manifest {
+		attributes(
+			'Automatic-Module-Name': 'com.labymedia.ultralight'
+		)
+	}
+}
+
 processResources {
     from(nativeBinaries) {
         into "native-binaries"

--- a/ultralight-java-databind/build.gradle
+++ b/ultralight-java-databind/build.gradle
@@ -6,11 +6,11 @@ plugins {
 group 'com.labymedia'
 
 jar {
-	manifest {
-		attributes(
-			'Automatic-Module-Name': 'com.labymedia.ultralight.databind'
-		)
-	}
+    manifest {
+        attributes(
+            'Automatic-Module-Name': 'com.labymedia.ultralight.databind'
+        )
+    }
 }
 
 dependencies {

--- a/ultralight-java-databind/build.gradle
+++ b/ultralight-java-databind/build.gradle
@@ -5,6 +5,14 @@ plugins {
 
 group 'com.labymedia'
 
+jar {
+	manifest {
+		attributes(
+			'Automatic-Module-Name': 'com.labymedia.ultralight.databind'
+		)
+	}
+}
+
 dependencies {
     implementation project(':ultralight-java-base')
 }

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/Databind.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/Databind.java
@@ -17,12 +17,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight;
+package com.labymedia.ultralight.databind;
 
-import com.labymedia.ultralight.context.ContextProviderFactory;
+import com.labymedia.ultralight.databind.cache.JavascriptClassCache;
+import com.labymedia.ultralight.databind.context.ContextProviderFactory;
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 import com.labymedia.ultralight.javascript.JavascriptClass;
-import com.labymedia.ultralight.cache.JavascriptClassCache;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
 
 /**
  * Representation of Databind instances.

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
@@ -17,13 +17,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight;
+package com.labymedia.ultralight.databind;
 
-import com.labymedia.ultralight.context.ContextProviderFactory;
-import com.labymedia.ultralight.cache.JavascriptClassCache;
-import com.labymedia.ultralight.cache.NaiveJavascriptClassCache;
-import com.labymedia.ultralight.call.HeuristicMethodChooser;
-import com.labymedia.ultralight.call.MethodChooser;
+import com.labymedia.ultralight.databind.cache.JavascriptClassCache;
+import com.labymedia.ultralight.databind.cache.NaiveJavascriptClassCache;
+import com.labymedia.ultralight.databind.call.HeuristicMethodChooser;
+import com.labymedia.ultralight.databind.call.MethodChooser;
+import com.labymedia.ultralight.databind.context.ContextProviderFactory;
 
 /**
  * Databind configuration.

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptClass.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptClass.java
@@ -17,14 +17,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight;
+package com.labymedia.ultralight.databind;
 
-import com.labymedia.ultralight.cache.JavascriptClassCache;
-import com.labymedia.ultralight.call.CallData;
 import com.labymedia.ultralight.javascript.*;
 import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
-import com.labymedia.ultralight.call.MethodChooser;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
+import com.labymedia.ultralight.databind.cache.JavascriptClassCache;
+import com.labymedia.ultralight.databind.call.CallData;
+import com.labymedia.ultralight.databind.call.MethodChooser;
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 
 import java.lang.reflect.*;
 import java.util.*;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptExplicitAPI.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptExplicitAPI.java
@@ -17,11 +17,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight;
+package com.labymedia.ultralight.databind;
 
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 import com.labymedia.ultralight.javascript.*;
 import com.labymedia.ultralight.javascript.*;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptMethodHandler.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptMethodHandler.java
@@ -17,14 +17,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight;
+package com.labymedia.ultralight.databind;
 
-import com.labymedia.ultralight.call.CallData;
+import com.labymedia.ultralight.databind.call.CallData;
+import com.labymedia.ultralight.databind.call.MethodChooser;
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 import com.labymedia.ultralight.javascript.*;
 import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
-import com.labymedia.ultralight.call.MethodChooser;
 import com.labymedia.ultralight.javascript.*;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/api/InjectJavascriptContext.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/api/InjectJavascriptContext.java
@@ -17,9 +17,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.api;
+package com.labymedia.ultralight.databind.api;
 
-import com.labymedia.ultralight.Databind;
+import com.labymedia.ultralight.databind.Databind;
 import com.labymedia.ultralight.javascript.JavascriptContext;
 
 import java.lang.annotation.ElementType;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/api/JavaAPI.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/api/JavaAPI.java
@@ -17,10 +17,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.api;
+package com.labymedia.ultralight.databind.api;
 
-import com.labymedia.ultralight.Databind;
-import com.labymedia.ultralight.DatabindJavascriptClass;
+import com.labymedia.ultralight.databind.Databind;
+import com.labymedia.ultralight.databind.DatabindJavascriptClass;
 import com.labymedia.ultralight.javascript.JavascriptContext;
 import com.labymedia.ultralight.javascript.JavascriptObject;
 

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/cache/JavascriptClassCache.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/cache/JavascriptClassCache.java
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.cache;
+package com.labymedia.ultralight.databind.cache;
 
 import com.labymedia.ultralight.javascript.JavascriptClass;
 

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/cache/NaiveJavascriptClassCache.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/cache/NaiveJavascriptClassCache.java
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.cache;
+package com.labymedia.ultralight.databind.cache;
 
 import com.labymedia.ultralight.javascript.JavascriptClass;
 

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/CallData.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/CallData.java
@@ -17,12 +17,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.call;
+package com.labymedia.ultralight.databind.call;
 
+import com.labymedia.ultralight.databind.api.InjectJavascriptContext;
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 import com.labymedia.ultralight.javascript.JavascriptContext;
 import com.labymedia.ultralight.javascript.JavascriptValue;
-import com.labymedia.ultralight.api.InjectJavascriptContext;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Executable;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
@@ -17,12 +17,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.call;
+package com.labymedia.ultralight.databind.call;
 
-import com.labymedia.ultralight.api.InjectJavascriptContext;
+import com.labymedia.ultralight.databind.api.InjectJavascriptContext;
+import com.labymedia.ultralight.databind.utils.JavascriptConversionUtils;
 import com.labymedia.ultralight.javascript.JavascriptObject;
 import com.labymedia.ultralight.javascript.JavascriptValue;
-import com.labymedia.ultralight.utils.JavascriptConversionUtils;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Modifier;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/MethodChooser.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/MethodChooser.java
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.call;
+package com.labymedia.ultralight.databind.call;
 
 import com.labymedia.ultralight.javascript.JavascriptValue;
 

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/context/ContextProvider.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/context/ContextProvider.java
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.context;
+package com.labymedia.ultralight.databind.context;
 
 import com.labymedia.ultralight.javascript.JavascriptContextLock;
 

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/context/ContextProviderFactory.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/context/ContextProviderFactory.java
@@ -17,9 +17,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.context;
+package com.labymedia.ultralight.databind.context;
 
-import com.labymedia.ultralight.DatabindConfiguration;
+import com.labymedia.ultralight.databind.DatabindConfiguration;
 import com.labymedia.ultralight.javascript.JavascriptValue;
 
 /**

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInterfaceBinder.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInterfaceBinder.java
@@ -17,10 +17,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.utils;
+package com.labymedia.ultralight.databind.utils;
 
-import com.labymedia.ultralight.Databind;
-import com.labymedia.ultralight.context.ContextProvider;
+import com.labymedia.ultralight.databind.Databind;
+import com.labymedia.ultralight.databind.context.ContextProvider;
 import com.labymedia.ultralight.javascript.JavascriptObject;
 
 import java.lang.reflect.Method;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInvocationHandler.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInvocationHandler.java
@@ -17,10 +17,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.utils;
+package com.labymedia.ultralight.databind.utils;
 
-import com.labymedia.ultralight.Databind;
-import com.labymedia.ultralight.context.ContextProvider;
+import com.labymedia.ultralight.databind.Databind;
+import com.labymedia.ultralight.databind.context.ContextProvider;
 import com.labymedia.ultralight.ffi.gc.DeletableObject;
 import com.labymedia.ultralight.javascript.JavascriptContext;
 import com.labymedia.ultralight.javascript.JavascriptObject;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
@@ -17,10 +17,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package com.labymedia.ultralight.utils;
+package com.labymedia.ultralight.databind.utils;
 
-import com.labymedia.ultralight.Databind;
-import com.labymedia.ultralight.DatabindJavascriptClass;
+import com.labymedia.ultralight.databind.Databind;
+import com.labymedia.ultralight.databind.DatabindJavascriptClass;
 import com.labymedia.ultralight.javascript.JavascriptClass;
 import com.labymedia.ultralight.javascript.JavascriptContext;
 import com.labymedia.ultralight.javascript.JavascriptObject;


### PR DESCRIPTION
This PR implements the package renaming of project ultralight-java-databind as well as the simple modularization via Automatic-Module-Name as discussed in #35 . This is meant as a start to make ultralight-java usable for Java 9+ modules. 2nd step will be the integration of proper module-info (e.g. as part of a MR Jar).