### PR TITLE
Fix wrong JS conversion for object parameter types

### DIFF
--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
@@ -60,12 +60,13 @@ public final class HeuristicMethodChooser implements MethodChooser {
             // It is required to know if we need to shift parameter selection by one if the method
             // needs a Javascript context
             boolean injectContext = executable.isAnnotationPresent(InjectJavascriptContext.class);
-
+            int paramMod = injectContext ? 1 : 0;
+            
             int currentPenalty = 0;
             CallData.VarArgsType varArgsType = null;
 
             Parameter[] parameters = executable.getParameters();
-            if (parameters.length != sourceParameterTypes.length + (injectContext ? 1 : 0)) {
+            if (parameters.length != sourceParameterTypes.length + paramMod) {
                 // Parameter count does not match
                 if (!executable.isVarArgs() || sourceParameterTypes.length < parameters.length - (injectContext ? 0 : 1)) {
                     // The method is either not a var args executable or even when the var args are not filled, the
@@ -74,25 +75,24 @@ public final class HeuristicMethodChooser implements MethodChooser {
                 }
             }
 
-            for (int i = 0; i < parameters.length - (injectContext ? 1 : 0); i++) {
+            for (int i = 0; i < parameters.length - paramMod; i++) {
                 Class<?> type = sourceParameterTypes[i];
                 if (type == null) {
                     // null/undefined parameter provided
                     continue;
                 }
 
-                if (i + (injectContext ? 1 : 0) == parameters.length - 1 && executable.isVarArgs()) {
+                if (i + paramMod == parameters.length - 1 && executable.isVarArgs()) {
                     // Last parameter is var args, special handling required
                     if (sourceParameterTypes.length < parameters.length) {
                         // Var args not supplied at all
                         varArgsType = CallData.VarArgsType.EMPTY;
                     } else if (type.isArray() && sourceParameterTypes.length == parameters.length) {
-                        if (parameters[i + (injectContext ? 1 : 0)].getType().isAssignableFrom(type)) {
+                        if (parameters[i + paramMod].getType().isAssignableFrom(type)) {
                             // Var args array can be passed through as the array types match
                             varArgsType = CallData.VarArgsType.PASS_THROUGH;
                         } else {
-                            if (!parameters[i + (injectContext ? 1 : 0)].getType().getComponentType()
-                                    .isAssignableFrom(type)) {
+                            if (!parameters[i + paramMod].getType().getComponentType().isAssignableFrom(type)) {
                                 // Method parameter can't be compacted down
                                 continue tryNextMethod;
                             }
@@ -109,7 +109,7 @@ public final class HeuristicMethodChooser implements MethodChooser {
                         for (int x = i; x < sourceParameterTypes.length; x++) {
                             // Sum up the penalties for every method parameter
                             int argPenalty = calculatePenalty(
-                                    parameters[i + (injectContext ? 1 : 0)].getType().getComponentType(),
+                                    parameters[i + paramMod].getType().getComponentType(),
                                     sourceParameterTypes[x],
                                     javascriptValues[x]
                             );
@@ -126,7 +126,7 @@ public final class HeuristicMethodChooser implements MethodChooser {
                     }
                 } else {
                     int argPenalty = calculatePenalty(
-                            parameters[i + (injectContext ? 1 : 0)].getType(),
+                            parameters[i + paramMod].getType(),
                             sourceParameterTypes[i],
                             javascriptValues[i]
                     );
@@ -217,7 +217,11 @@ public final class HeuristicMethodChooser implements MethodChooser {
     }
 
     private int calculatePenalty(Class<?> target, Class<?> source, JavascriptValue value) {
-        if (target == JavascriptValue.class) {
+        if (target == Object.class) {
+            // The target accepts any parameter, but higher penalty because there might be methods that are
+            // more specific
+            return 100;
+        } else if (target == JavascriptValue.class) {
             // No casting required at all, as the value can be passed directly
             return 0;
         } else if (target == JavascriptObject.class) {

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
@@ -227,13 +227,16 @@ public final class JavascriptConversionUtils {
                         .toObject().callAsFunction(value.toObject()).toNumber();
                 return new Date(millis);
             } else if (value.isArray()) {
-                if (!type.isArray()) {
+                // The target might use any object, so just convert the JS array to an Object[]
+                boolean anyType = type == Object.class;
+
+                if (!type.isArray() && !anyType) {
                     throw new IllegalArgumentException("Can not convert a Javascript array to " + type.getName());
                 }
 
                 // Prepare an array reflectively
                 int size = (int) object.getProperty("length").toNumber();
-                Class<?> componentType = type.getComponentType();
+                Class<?> componentType = anyType ? Object.class : type.getComponentType();
                 Object objects = Array.newInstance(componentType, size);
 
                 for (int i = 0; i < size; i++) {


### PR DESCRIPTION
This PR fixes:
- Conversion of JS arrays to Java arrays when the parameter type is `Object`. Previously it would just throw an exception because `Object` is not an array, but `Object` can be anything.
- Choosing methods with a parameter type `Object` and a primitive parameter. It would just ignore the method because it would only map for example JS booleans to `boolean` and `Boolean` in Java and not to `Object`.
  Now, if `Object` is provided as a parameter type, it will add a penalty of `100` so that methods with a more specific parameter type will be preferred.