### PR TITLE
Databind performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext.commonPublish = { Project currentProject, Closure config ->
             def releaseRepo = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             def snapshotRepo = "https://oss.sonatype.org/content/repositories/snapshots/"
 
-            if(!version.endsWith("-UNSTABLE")) {
+            if (!version.endsWith("-UNSTABLE")) {
                 maven {
                     url version.endsWith("-SNAPSHOT") ? snapshotRepo : releaseRepo
                     name "OSS${version.endsWith("-SNAPSHOT") ? "Snapshots" : "Release"}HostingRepository"
@@ -72,7 +72,7 @@ ext.commonPublish = { Project currentProject, Closure config ->
         }
     }
 
-    if(rootProject.hasProperty("enableSigning")) {
+    if (rootProject.hasProperty("enableSigning")) {
         currentProject.signing {
             def signingKey = getSigningProperty("KEY")
             def signingPassword = getSigningProperty("PASSWORD")
@@ -92,6 +92,9 @@ subprojects {
     pluginManager.withPlugin("java") {
         apply plugin: "net.minecrell.licenser"
         apply plugin: "signing"
+
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
 
         license {
             header = rootProject.file("LICENSE_HEADER")

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,6 @@ rootProject.name = 'ultralight-java'
 include 'ultralight-java-base'
 include 'ultralight-java-native'
 include 'ultralight-java-databind'
+include 'ultralight-java-databind-generated-callers'
 
 include 'example:lwjgl3-opengl'
-include 'ultralight-java-databind-generated-callers'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,3 +5,4 @@ include 'ultralight-java-native'
 include 'ultralight-java-databind'
 
 include 'example:lwjgl3-opengl'
+include 'ultralight-java-databind-generated-callers'

--- a/ultralight-java-databind-generated-callers/build.gradle
+++ b/ultralight-java-databind-generated-callers/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+group 'com.labymedia'
+
+jar {
+    manifest {
+        attributes(
+                'Automatic-Module-Name': 'com.labymedia.ultralight.databind'
+        )
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':ultralight-java-base')
+    implementation project(':ultralight-java-databind')
+    implementation group: 'org.javassist', name: 'javassist', version: '3.27.0-GA'
+}
+
+commonPublish(project) {
+    pom {
+        name = "UltralightJava Databind"
+        description = "Automatic bindings from Java to Javascript for UltralightJava"
+    }
+}

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/CallerGenerationException.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/CallerGenerationException.java
@@ -19,8 +19,14 @@
 
 package com.labymedia.ultralight.databind.call.property.generated;
 
+/**
+ * Exception thrown when there was a problem generating a new {@link SingleGeneratedPropertyCaller}.
+ */
 public class CallerGenerationException extends RuntimeException {
 
+    /**
+     * {@inheritDoc}
+     */
     public CallerGenerationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/CallerGenerationException.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/CallerGenerationException.java
@@ -1,0 +1,27 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property.generated;
+
+public class CallerGenerationException extends RuntimeException {
+
+    public CallerGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/GeneratedPropertyCaller.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/GeneratedPropertyCaller.java
@@ -20,6 +20,7 @@
 package com.labymedia.ultralight.databind.call.property.generated;
 
 import com.labymedia.ultralight.databind.call.property.PropertyCaller;
+import com.labymedia.ultralight.databind.call.property.ReflectivePropertyCaller;
 import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
 import javassist.CannotCompileException;
 import javassist.NotFoundException;
@@ -32,12 +33,30 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Calls properties on java objects or classes via lazy-bytecode-generated {@link SingleGeneratedPropertyCaller}s.
+ * This implementation is recommended if there are a lot of calls in a short time on the same property.
+ * Although this implementation is faster than {@link ReflectivePropertyCaller},
+ * the first call might be slower because of the lazy generation.
+ */
 public class GeneratedPropertyCaller implements PropertyCaller {
 
+    /**
+     * All already generated {@link SingleGeneratedPropertyCaller}s for methods.
+     */
     private final Map<Method, SingleGeneratedPropertyCaller> methodCallers;
+    /**
+     * All already generated {@link SingleGeneratedPropertyCaller}s for constructors.
+     */
     private final Map<Constructor<?>, SingleGeneratedPropertyCaller> constructorCallers;
+    /**
+     * All already generated {@link SingleGeneratedPropertyCaller}s for fields.
+     */
     private final Map<Field, SingleGeneratedPropertyCaller> fieldCallers;
 
+    /**
+     * Generator for new {@link SingleGeneratedPropertyCaller}s.
+     */
     private final PropertyCallerGenerator callerGenerator;
 
     private GeneratedPropertyCaller() {
@@ -48,6 +67,9 @@ public class GeneratedPropertyCaller implements PropertyCaller {
         this.callerGenerator = new PropertyCallerGenerator();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException {
         SingleGeneratedPropertyCaller propertyCaller = this.methodCallers.computeIfAbsent(method, key -> {
@@ -65,6 +87,9 @@ public class GeneratedPropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException {
         SingleGeneratedPropertyCaller propertyCaller = this.constructorCallers.computeIfAbsent(constructor, key -> {
@@ -82,6 +107,9 @@ public class GeneratedPropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callFieldGet(Object instance, Field field) throws JavascriptInteropException {
         SingleGeneratedPropertyCaller propertyCaller = this.fieldCallers.computeIfAbsent(field, key -> {
@@ -99,6 +127,9 @@ public class GeneratedPropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException {
         SingleGeneratedPropertyCaller propertyCaller = this.fieldCallers.computeIfAbsent(field, key -> {
@@ -116,8 +147,14 @@ public class GeneratedPropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * Factory for {@link GeneratedPropertyCaller}.
+     */
     public static class Factory implements PropertyCaller.Factory {
 
+        /**
+         * @return A new {@link GeneratedPropertyCaller} instance
+         */
         @Override
         public GeneratedPropertyCaller create() {
             return new GeneratedPropertyCaller();

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/GeneratedPropertyCaller.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/GeneratedPropertyCaller.java
@@ -1,0 +1,126 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property.generated;
+
+import com.labymedia.ultralight.databind.call.property.PropertyCaller;
+import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
+import javassist.CannotCompileException;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GeneratedPropertyCaller implements PropertyCaller {
+
+    private final Map<Method, SingleGeneratedPropertyCaller> methodCallers;
+    private final Map<Constructor<?>, SingleGeneratedPropertyCaller> constructorCallers;
+    private final Map<Field, SingleGeneratedPropertyCaller> fieldCallers;
+
+    private final PropertyCallerGenerator callerGenerator;
+
+    private GeneratedPropertyCaller() {
+        this.methodCallers = new HashMap<>();
+        this.constructorCallers = new HashMap<>();
+        this.fieldCallers = new HashMap<>();
+
+        this.callerGenerator = new PropertyCallerGenerator();
+    }
+
+    @Override
+    public Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException {
+        SingleGeneratedPropertyCaller propertyCaller = this.methodCallers.computeIfAbsent(method, key -> {
+            try {
+                return this.callerGenerator.generateMethodCaller(method);
+            } catch (NotFoundException | CannotCompileException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException | IOException exception) {
+                throw new CallerGenerationException("Failed to generate caller for method " + method.getName(), exception);
+            }
+        });
+
+        try {
+            return propertyCaller.callProperty(instance, parameters);
+        } catch (Exception exception) {
+            throw new JavascriptInteropException(method.getName() + " threw an exception", exception);
+        }
+    }
+
+    @Override
+    public Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException {
+        SingleGeneratedPropertyCaller propertyCaller = this.constructorCallers.computeIfAbsent(constructor, key -> {
+            try {
+                return this.callerGenerator.generateConstructorCaller(key);
+            } catch (NotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException | IOException | CannotCompileException exception) {
+                throw new CallerGenerationException("Failed to generate caller for constructor", exception);
+            }
+        });
+
+        try {
+            return propertyCaller.callProperty(null, parameters);
+        } catch (Exception exception) {
+            throw new JavascriptInteropException("Constructor call threw an exception", exception);
+        }
+    }
+
+    @Override
+    public Object callFieldGet(Object instance, Field field) throws JavascriptInteropException {
+        SingleGeneratedPropertyCaller propertyCaller = this.fieldCallers.computeIfAbsent(field, key -> {
+            try {
+                return this.callerGenerator.generateFieldCaller(key);
+            } catch (NotFoundException | CannotCompileException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException | IOException exception) {
+                throw new CallerGenerationException("Failed to generate caller for field " + field.getName(), exception);
+            }
+        });
+
+        try {
+            return propertyCaller.callProperty(instance, null);
+        } catch (Exception exception) {
+            throw new JavascriptInteropException("Field call for " + field.getName() + " threw an exception", exception);
+        }
+    }
+
+    @Override
+    public void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException {
+        SingleGeneratedPropertyCaller propertyCaller = this.fieldCallers.computeIfAbsent(field, key -> {
+            try {
+                return this.callerGenerator.generateFieldCaller(key);
+            } catch (NotFoundException | CannotCompileException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException | IOException exception) {
+                throw new CallerGenerationException("Failed to generate caller for field " + field.getName(), exception);
+            }
+        });
+
+        try {
+            propertyCaller.callProperty(instance, new Object[]{value});
+        } catch (Exception exception) {
+            throw new JavascriptInteropException("Field call for " + field.getName() + " threw an exception", exception);
+        }
+    }
+
+    public static class Factory implements PropertyCaller.Factory {
+
+        @Override
+        public GeneratedPropertyCaller create() {
+            return new GeneratedPropertyCaller();
+        }
+    }
+}

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/PropertyCallerGenerator.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/PropertyCallerGenerator.java
@@ -1,0 +1,236 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property.generated;
+
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtNewMethod;
+import javassist.NotFoundException;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.security.SecureClassLoader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class PropertyCallerGenerator {
+
+    private static final Class<?> GENERATION_INTERFACE = SingleGeneratedPropertyCaller.class;
+
+    private static final Method CALL_METHOD = GENERATION_INTERFACE.getDeclaredMethods()[0];
+
+    private static final String CLASS_NAME_BASE = "Generated" + GENERATION_INTERFACE + "_%s";
+
+    private static final String INSTANCE_PARAMETER_NAME = "instance";
+
+    private static final String PARAMETERS_PARAMETER_NAME = "parameters";
+
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<Class<?>, Class<?>>() {
+        {
+            this.put(boolean.class, Boolean.class);
+            this.put(byte.class, Byte.class);
+            this.put(char.class, Character.class);
+            this.put(double.class, Double.class);
+            this.put(float.class, Float.class);
+            this.put(int.class, Integer.class);
+            this.put(long.class, Long.class);
+            this.put(short.class, Short.class);
+        }
+    };
+
+    private final DefinableClassLoader classLoader;
+
+    private final ClassPool classPool;
+
+    public PropertyCallerGenerator() {
+        this.classLoader = new DefinableClassLoader(this.getClass().getClassLoader());
+        this.classPool = ClassPool.getDefault();
+    }
+
+    public SingleGeneratedPropertyCaller generateMethodCaller(Method method) throws NotFoundException, CannotCompileException, IOException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        boolean returnsVoid = method.getReturnType().equals(void.class);
+
+        StringBuilder methodContentBuilder = new StringBuilder(returnsVoid ? "" : "return ");
+        this.wrapPrimitiveType(methodContentBuilder, method.getReturnType(), builder -> {
+            this.castInstance(builder, method.getDeclaringClass(), method.getModifiers())
+                    .append(".")
+                    .append(method.getName())
+                    .append("(");
+            this.appendParameters(builder, method.getParameterTypes())
+                    .append(")");
+        }).append(";");
+
+        if (returnsVoid) {
+            methodContentBuilder.append("return null;");
+        }
+        return this.generateCaller(methodContentBuilder.toString());
+    }
+
+    public SingleGeneratedPropertyCaller generateConstructorCaller(Constructor<?> constructor) throws NotFoundException, CannotCompileException, IOException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        String declaringClassName = constructor.getDeclaringClass().getName();
+
+        StringBuilder methodContentBuilder = new StringBuilder("return new ")
+                .append(declaringClassName)
+                .append("(");
+        this.appendParameters(methodContentBuilder, constructor.getParameterTypes()).append(");");
+        return this.generateCaller(methodContentBuilder.toString());
+    }
+
+    public SingleGeneratedPropertyCaller generateFieldCaller(Field field) throws NotFoundException, CannotCompileException, IOException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        Class<?> type = field.getType();
+
+        StringBuilder methodContentBuilder = new StringBuilder("if (")
+                .append(PARAMETERS_PARAMETER_NAME)
+                .append(" != null && ")
+                .append(PARAMETERS_PARAMETER_NAME)
+                .append(".length == 1) { ");
+
+        this.castInstance(methodContentBuilder, field.getDeclaringClass(), field.getModifiers())
+                .append(".")
+                .append(field.getName())
+                .append(" = ");
+
+        this.castParameter(methodContentBuilder, type, 0)
+                .append(";")
+                .append(" return null; } return ");
+
+        this.wrapPrimitiveType(methodContentBuilder, type, builder ->
+                this.castInstance(builder, field.getDeclaringClass(), field.getModifiers())
+                        .append(".")
+                        .append(field.getName()))
+                .append(";");
+        return this.generateCaller(methodContentBuilder.toString());
+    }
+
+    private SingleGeneratedPropertyCaller generateCaller(String methodContent) throws NotFoundException, CannotCompileException, IOException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        CtClass ctClass = this.classPool.makeClass(
+                String.format(CLASS_NAME_BASE, UUID.randomUUID().toString().replace("-", "")));
+        ctClass.addInterface(this.classPool.get(GENERATION_INTERFACE.getName()));
+
+        ctClass.addMethod(CtNewMethod.make(String.format(
+                "public Object %s(Object %s, Object[] %s) { %s }",
+                CALL_METHOD.getName(),
+                INSTANCE_PARAMETER_NAME,
+                PARAMETERS_PARAMETER_NAME,
+                methodContent), ctClass));
+
+        Class<?> generatedClass = this.classLoader.defineClass(ctClass.getName(), ctClass.toBytecode());
+        return (SingleGeneratedPropertyCaller) generatedClass.getConstructor().newInstance();
+    }
+
+    private StringBuilder castInstance(StringBuilder builder, Class<?> type, int propertyModifiers) {
+        boolean isStatic = Modifier.isStatic(propertyModifiers);
+
+        if (!isStatic) {
+            builder.append("((")
+                    .append(this.getCastType(type))
+                    .append(")");
+        }
+        builder.append(isStatic ? type.getName() : INSTANCE_PARAMETER_NAME);
+        if (!isStatic) {
+            builder.append(")");
+        }
+
+        return builder;
+    }
+
+    private StringBuilder castParameter(StringBuilder builder, Class<?> type, int index) {
+        Class<?> wrappedType = PRIMITIVE_TO_WRAPPER.get(type);
+        boolean isWrapped = wrappedType != null;
+
+        builder.append("((")
+                .append(this.getCastType(type))
+                .append(")")
+                .append(PARAMETERS_PARAMETER_NAME)
+                .append("[")
+                .append(index)
+                .append("]")
+                .append(")");
+
+        if (isWrapped) {
+            builder.append(".")
+                    .append(type.getName())
+                    .append("Value()");
+        }
+
+        return builder;
+    }
+
+    private String getCastType(Class<?> type) {
+        Class<?> wrappedType = PRIMITIVE_TO_WRAPPER.get(type);
+        Class<?> rawType = type.getComponentType() != null ? type.getComponentType() : type;
+
+        StringBuilder builder = new StringBuilder(wrappedType != null ? wrappedType.getName() : rawType.getName());
+        for (; type.isArray(); type = type.getComponentType()) {
+            builder.append("[]");
+        }
+
+        return builder.toString();
+    }
+
+    private StringBuilder wrapPrimitiveType(StringBuilder builder, Class<?> type, Consumer<StringBuilder> propertyReturner) {
+        Class<?> wrappedType = PRIMITIVE_TO_WRAPPER.get(type);
+        boolean isWrapped = wrappedType != null;
+
+        if (isWrapped) {
+            builder.append(wrappedType.getName())
+                    .append(".valueOf(");
+        }
+
+        propertyReturner.accept(builder);
+
+        if (isWrapped) {
+            builder.append(")");
+        }
+
+        return builder;
+    }
+
+    private StringBuilder appendParameters(StringBuilder builder, Class<?>[] parameterTypes) {
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Class<?> parameterType = parameterTypes[i];
+            this.castParameter(builder, parameterType, i);
+
+            if (parameterTypes.length != (i + 1)) {
+                builder.append(",");
+            }
+        }
+
+        return builder;
+    }
+
+    private static class DefinableClassLoader extends SecureClassLoader {
+
+        public DefinableClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        public Class<?> defineClass(String className, byte[] byteCode) {
+            return super.defineClass(className, byteCode, 0, byteCode.length);
+        }
+    }
+}

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/PropertyCallerGenerator.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/PropertyCallerGenerator.java
@@ -37,6 +37,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+/**
+ * Generates certain {@link SingleGeneratedPropertyCaller}s.
+ */
 public class PropertyCallerGenerator {
 
     private static final Class<?> GENERATION_INTERFACE = SingleGeneratedPropertyCaller.class;
@@ -121,6 +124,7 @@ public class PropertyCallerGenerator {
     public SingleGeneratedPropertyCaller generateFieldCaller(Field field) throws NotFoundException, CannotCompileException, IOException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         Class<?> type = field.getType();
 
+        // when the caller is called with arguments, the field value will be set to the first argument
         StringBuilder methodContentBuilder = new StringBuilder("if (")
                 .append(PARAMETERS_PARAMETER_NAME)
                 .append(" != null && ")
@@ -136,6 +140,7 @@ public class PropertyCallerGenerator {
                 .append(";")
                 .append(" return null; } return ");
 
+        // when no arguments are present, just return the field value
         this.wrapPrimitiveType(methodContentBuilder, type, builder ->
                 this.castInstance(builder, field.getDeclaringClass(), field.getModifiers())
                         .append(".")
@@ -211,6 +216,9 @@ public class PropertyCallerGenerator {
                 .append(")");
 
         if (isWrapped) {
+            // unwrapping the wrapper type to its primitive
+            // this is necessary to avoid verify errors,
+            // the javassist compiler has some issues with primitives and their wrappers
             builder.append(".")
                     .append(type.getName())
                     .append("Value()");
@@ -250,6 +258,9 @@ public class PropertyCallerGenerator {
         boolean isWrapped = wrappedType != null;
 
         if (isWrapped) {
+            // wrapping primitive type to its wrapper
+            // this is necessary to avoid verify errors,
+            // the javassist compiler has some issues with primitives and their wrappers
             builder.append(wrappedType.getName())
                     .append(".valueOf(");
         }

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/SingleGeneratedPropertyCaller.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/SingleGeneratedPropertyCaller.java
@@ -1,0 +1,25 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property.generated;
+
+public interface SingleGeneratedPropertyCaller {
+
+    Object callProperty(Object instance, Object[] parameters);
+}

--- a/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/SingleGeneratedPropertyCaller.java
+++ b/ultralight-java-databind-generated-callers/src/main/java/com/labymedia/ultralight/databind/call/property/generated/SingleGeneratedPropertyCaller.java
@@ -19,7 +19,17 @@
 
 package com.labymedia.ultralight.databind.call.property.generated;
 
+/**
+ * Represents a bytecode-generated caller which directly calls a certain property on a java object or class without reflection.
+ */
 public interface SingleGeneratedPropertyCaller {
 
+    /**
+     * Calls the property of the object or class directly.
+     *
+     * @param instance   The instance the property belongs to or {@code null} if the property belongs to a class.
+     * @param parameters The parameters the property should be called with or {@code null} if the property does not support arguments.
+     * @return The result of the call or {@code null} if the property has no result
+     */
     Object callProperty(Object instance, Object[] parameters);
 }

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
@@ -23,6 +23,8 @@ import com.labymedia.ultralight.databind.cache.JavascriptClassCache;
 import com.labymedia.ultralight.databind.cache.NaiveJavascriptClassCache;
 import com.labymedia.ultralight.databind.call.HeuristicMethodChooser;
 import com.labymedia.ultralight.databind.call.MethodChooser;
+import com.labymedia.ultralight.databind.call.property.PropertyCaller;
+import com.labymedia.ultralight.databind.call.property.ReflectivePropertyCaller;
 import com.labymedia.ultralight.databind.context.ContextProviderFactory;
 
 /**
@@ -31,6 +33,7 @@ import com.labymedia.ultralight.databind.context.ContextProviderFactory;
 public final class DatabindConfiguration {
     private final JavascriptClassCache classCache;
     private final MethodChooser methodChooser;
+    private final PropertyCaller.Factory propertyCallerFactory;
     private final boolean automaticPrototype;
     private final ContextProviderFactory contextProviderFactory;
 
@@ -40,18 +43,20 @@ public final class DatabindConfiguration {
      *
      * @param classCache             The class cache used by this configuration
      * @param methodChooser          The method chooser used by this configuration
+     * @param propertyCallerFactory
      * @param automaticPrototype     If {@code true}, automatic prototyping is enabled
      * @param contextProviderFactory The factory for binding context providers, or {@code null}, if this feature
-     *                               is not required
      */
     private DatabindConfiguration(
             JavascriptClassCache classCache,
             MethodChooser methodChooser,
+            PropertyCaller.Factory propertyCallerFactory,
             boolean automaticPrototype,
             ContextProviderFactory contextProviderFactory
     ) {
         this.classCache = classCache;
         this.methodChooser = methodChooser;
+        this.propertyCallerFactory = propertyCallerFactory;
         this.automaticPrototype = automaticPrototype;
         this.contextProviderFactory = contextProviderFactory;
     }
@@ -72,6 +77,10 @@ public final class DatabindConfiguration {
      */
     public MethodChooser methodChooser() {
         return methodChooser;
+    }
+
+    public PropertyCaller.Factory propertyCallerFactory() {
+        return propertyCallerFactory;
     }
 
     /**
@@ -107,6 +116,7 @@ public final class DatabindConfiguration {
     public static class Builder {
         private JavascriptClassCache classCache;
         private MethodChooser methodChooser;
+        private PropertyCaller.Factory propertyCallerFactory;
         private boolean automaticPrototype;
         private ContextProviderFactory contextProviderFactory;
 
@@ -117,6 +127,7 @@ public final class DatabindConfiguration {
         private Builder() {
             this.classCache = new NaiveJavascriptClassCache();
             this.methodChooser = new HeuristicMethodChooser();
+            this.propertyCallerFactory = new ReflectivePropertyCaller.Factory();
             this.automaticPrototype = true;
         }
 
@@ -139,6 +150,11 @@ public final class DatabindConfiguration {
          */
         public Builder methodChooser(MethodChooser methodChooser) {
             this.methodChooser = methodChooser;
+            return this;
+        }
+
+        public Builder propertyCallerFactory(PropertyCaller.Factory propertyCallerFactory) {
+            this.propertyCallerFactory = propertyCallerFactory;
             return this;
         }
 
@@ -171,7 +187,7 @@ public final class DatabindConfiguration {
          * @return The built {@link DatabindConfiguration}
          */
         public DatabindConfiguration build() {
-            return new DatabindConfiguration(classCache, methodChooser, automaticPrototype, contextProviderFactory);
+            return new DatabindConfiguration(classCache, methodChooser, propertyCallerFactory, automaticPrototype, contextProviderFactory);
         }
     }
 }

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindConfiguration.java
@@ -43,7 +43,7 @@ public final class DatabindConfiguration {
      *
      * @param classCache             The class cache used by this configuration
      * @param methodChooser          The method chooser used by this configuration
-     * @param propertyCallerFactory
+     * @param propertyCallerFactory  The factory creating the property caller used for calling properties on java objects and classes
      * @param automaticPrototype     If {@code true}, automatic prototyping is enabled
      * @param contextProviderFactory The factory for binding context providers, or {@code null}, if this feature
      */
@@ -79,6 +79,11 @@ public final class DatabindConfiguration {
         return methodChooser;
     }
 
+    /**
+     * Retrieves the property caller used for calling properties on java objects and classes.
+     *
+     * @return The property caller used for calling properties on java objects and classes
+     */
     public PropertyCaller.Factory propertyCallerFactory() {
         return propertyCallerFactory;
     }
@@ -153,6 +158,12 @@ public final class DatabindConfiguration {
             return this;
         }
 
+        /**
+         * Sets the property caller used for calling properties on java objects and classes.
+         *
+         * @param propertyCallerFactory The property caller to use
+         * @return this
+         */
         public Builder propertyCallerFactory(PropertyCaller.Factory propertyCallerFactory) {
             this.propertyCallerFactory = propertyCallerFactory;
             return this;

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptMethodHandler.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/DatabindJavascriptMethodHandler.java
@@ -54,7 +54,7 @@ public final class DatabindJavascriptMethodHandler {
      *
      * @param configuration   The configuration to use
      * @param conversionUtils The conversion utilities to use for converting objects
-     * @param propertyCaller
+     * @param propertyCaller  The property caller used for calling properties on java objects and classes
      * @param methodSet       The methods which can be invoked by this handler
      * @param name            The name of this handler class
      */
@@ -164,7 +164,7 @@ public final class DatabindJavascriptMethodHandler {
      *
      * @param configuration   The configuration to use
      * @param conversionUtils The conversion utilities to user for converting objects
-     * @param propertyCaller
+     * @param propertyCaller  The property caller used for calling properties on java objects and classes
      * @param methodSet       The sets of methods invocable by this handler
      * @param name            The name of this handler class
      * @return The created handler

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/HeuristicMethodChooser.java
@@ -53,7 +53,7 @@ public final class HeuristicMethodChooser implements MethodChooser {
             Collection<? extends T> possibilities, Class<?>[] sourceParameterTypes, JavascriptValue[] javascriptValues) {
         // The default penalty needs to be higher than the maximum penalty produced by the selection process
         int penalty = Integer.MAX_VALUE;
-        Set<CallData<T>> availableMethods = new HashSet<>();
+        List<CallData<T>> availableMethods = new ArrayList<>(possibilities.size());
 
         tryNextMethod:
         for (T executable : possibilities) {

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/PropertyCaller.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/PropertyCaller.java
@@ -25,18 +25,60 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+/**
+ * Represents an abstraction about calling properties on java objects or classes.
+ */
 public interface PropertyCaller {
 
+    /**
+     * Calls a method on a certain instance.
+     *
+     * @param instance   The instance the method belongs to or {@code null}, if static
+     * @param method     The method which should be called
+     * @param parameters The parameters the method should be called with
+     * @return The return value of the method or {@code null} if void
+     * @throws JavascriptInteropException If an error occurred while calling the method
+     */
     Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException;
 
+    /**
+     * Creates a new instance of a class by calling a certain constructor.
+     *
+     * @param constructor The constructor which should be called
+     * @param parameters  The parameters the constructor should be called with
+     * @return The new instance
+     * @throws JavascriptInteropException If an error occurred while calling the function
+     */
     Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException;
 
+    /**
+     * Returns the value from a certain field.
+     *
+     * @param instance The instance the field belongs to or {@code null} if static
+     * @param field    The field whose value should be returned
+     * @return The value of the field
+     * @throws JavascriptInteropException If an error occurred while getting the value from the field
+     */
     Object callFieldGet(Object instance, Field field) throws JavascriptInteropException;
 
+    /**
+     * Sets a value of a certain field.
+     *
+     * @param instance The instance the field belongs to or {@code null} if static
+     * @param field    The field whose value should be set
+     * @param value    The value to be set
+     * @throws JavascriptInteropException If an error occurred while setting the value of the field
+     */
     void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException;
 
+    /**
+     * Factory for {@link PropertyCaller}.
+     */
     interface Factory {
 
+        /**
+         * @return A new {@link PropertyCaller} instance
+         */
         PropertyCaller create();
     }
 }

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/PropertyCaller.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/PropertyCaller.java
@@ -1,0 +1,42 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property;
+
+import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public interface PropertyCaller {
+
+    Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException;
+
+    Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException;
+
+    Object callFieldGet(Object instance, Field field) throws JavascriptInteropException;
+
+    void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException;
+
+    interface Factory {
+
+        PropertyCaller create();
+    }
+}

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/ReflectivePropertyCaller.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/ReflectivePropertyCaller.java
@@ -26,8 +26,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * Calls properties on java objects or classes via reflection. Default implementation of {@link PropertyCaller}.
+ */
 public class ReflectivePropertyCaller implements PropertyCaller {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException {
         try {
@@ -39,6 +45,9 @@ public class ReflectivePropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException {
         try {
@@ -52,6 +61,9 @@ public class ReflectivePropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Object callFieldGet(Object instance, Field field) throws JavascriptInteropException {
         try {
@@ -61,6 +73,9 @@ public class ReflectivePropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException {
         try {
@@ -70,8 +85,14 @@ public class ReflectivePropertyCaller implements PropertyCaller {
         }
     }
 
+    /**
+     * Factory for {@link ReflectivePropertyCaller}
+     */
     public static class Factory implements PropertyCaller.Factory {
 
+        /**
+         * @return A new {@link ReflectivePropertyCaller} instance.
+         */
         @Override
         public ReflectivePropertyCaller create() {
             return new ReflectivePropertyCaller();

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/ReflectivePropertyCaller.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/call/property/ReflectivePropertyCaller.java
@@ -1,0 +1,80 @@
+/*
+ * Ultralight Java - Java wrapper for the Ultralight web engine
+ * Copyright (C) 2020 - 2021 LabyMedia and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.labymedia.ultralight.databind.call.property;
+
+import com.labymedia.ultralight.javascript.interop.JavascriptInteropException;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ReflectivePropertyCaller implements PropertyCaller {
+
+    @Override
+    public Object callMethod(Object instance, Method method, Object[] parameters) throws JavascriptInteropException {
+        try {
+            return method.invoke(instance, parameters);
+        } catch (IllegalAccessException exception) {
+            throw new JavascriptInteropException("Unable to access method: " + method.getName(), exception);
+        } catch (InvocationTargetException exception) {
+            throw new JavascriptInteropException(method.getName() + " threw an exception", exception);
+        }
+    }
+
+    @Override
+    public Object callConstructor(Constructor<?> constructor, Object[] parameters) throws JavascriptInteropException {
+        try {
+            return constructor.newInstance(parameters);
+        } catch (IllegalAccessException exception) {
+            throw new JavascriptInteropException("Unable to access constructor: " + constructor.getName(), exception);
+        } catch (InvocationTargetException exception) {
+            throw new JavascriptInteropException("Constructor threw an exception", exception);
+        } catch (InstantiationException exception) {
+            throw new JavascriptInteropException("Unable to create instance", exception);
+        }
+    }
+
+    @Override
+    public Object callFieldGet(Object instance, Field field) throws JavascriptInteropException {
+        try {
+            return field.get(instance);
+        } catch (IllegalAccessException exception) {
+            throw new JavascriptInteropException("Unable to access field: " + field.getName(), exception);
+        }
+    }
+
+    @Override
+    public void callFieldSet(Object instance, Field field, Object value) throws JavascriptInteropException {
+        try {
+            field.set(instance, value);
+        } catch (IllegalAccessException exception) {
+            throw new JavascriptInteropException("Unable to access field: " + field.getName(), exception);
+        }
+    }
+
+    public static class Factory implements PropertyCaller.Factory {
+
+        @Override
+        public ReflectivePropertyCaller create() {
+            return new ReflectivePropertyCaller();
+        }
+    }
+}

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInvocationHandler.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/FunctionalInvocationHandler.java
@@ -30,7 +30,9 @@ import com.labymedia.ultralight.javascript.JavascriptValue;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 /**
  * Invocation handler for Javascript functions bound to functional interfaces.
@@ -91,12 +93,11 @@ class FunctionalInvocationHandler implements InvocationHandler {
             return method.invoke(this, args);
         }
 
-        CountDownLatch awaiter = new CountDownLatch(1);
-        GuardedInvocationResult result = new GuardedInvocationResult();
+        CompletableFuture<Object> future = new CompletableFuture<>();
 
         contextProvider.syncWithJavascript((contextLock) -> {
             try {
-                synchronized(lock) {
+                synchronized (lock) {
                     JavascriptContext context = contextLock.getContext();
 
                     // Revive the Javascript value, this will effectively invalidate the protected value
@@ -112,21 +113,26 @@ class FunctionalInvocationHandler implements InvocationHandler {
                     protectedValue.get().value = object.protect();
 
                     JavascriptValue returnValue = object.callAsFunction(null, arguments);
-                    result.returnValue = databind.getConversionUtils().fromJavascript(
+                    future.complete(databind.getConversionUtils().fromJavascript(
                             returnValue,
-                            returnValue != null ? returnValue.getClass() : method.getReturnType()
-                    );
+                            returnValue.getClass()
+                    ));
                 }
-            } catch(Throwable t) {
+            } catch (Throwable t) {
                 // Capture exceptions to prevent deadlocking
-                result.throwable = t;
+                future.completeExceptionally(t);
             }
-            awaiter.countDown();
         });
-        awaiter.await();
 
-        if (result.throwable != null) {
-            Throwable t = result.throwable;
+        if (CompletableFuture.class.isAssignableFrom(method.getReturnType())) {
+            // A future is expected so we let the user handle it
+            return future;
+        }
+
+        try {
+            return future.get();
+        } catch (ExecutionException exception) {
+            Throwable t = exception.getCause();
 
             if (t instanceof RuntimeException || t instanceof Error) {
                 // Unchecked, rethrow as is
@@ -144,8 +150,6 @@ class FunctionalInvocationHandler implements InvocationHandler {
             // Checked exception which has not been declared as thrown by the interface method
             throw new RuntimeException("Exception thrown while invoking Javascript method", t);
         }
-
-        return result.returnValue;
     }
 
     /**
@@ -165,14 +169,6 @@ class FunctionalInvocationHandler implements InvocationHandler {
             this.contextProvider = contextProvider;
             this.value = value;
         }
-    }
-
-    /**
-     * Helper class for handling the results of asynchronous method invocations including exceptions.
-     */
-    private static class GuardedInvocationResult {
-        private Throwable throwable;
-        private Object returnValue;
     }
 
     /**

--- a/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
+++ b/ultralight-java-databind/src/main/java/com/labymedia/ultralight/databind/utils/JavascriptConversionUtils.java
@@ -88,12 +88,14 @@ public final class JavascriptConversionUtils {
             return context.makeString((String) object);
         } else if (javaClass.isArray()) {
             // Arrays required a recursive conversion
-            Object[] array = (Object[]) object;
-            JavascriptValue[] values = new JavascriptValue[array.length];
+            // Reflective access to handle primitive arrays too
+            int length = Array.getLength(object);
+            JavascriptValue[] values = new JavascriptValue[length];
 
-            for (int i = 0; i < array.length; i++) {
+            for (int i = 0; i < length; i++) {
                 // Recursive call
-                values[i] = toJavascript(context, array[i], array[i].getClass());
+                Object value = Array.get(object, i);
+                values[i] = toJavascript(context, value, value.getClass());
             }
 
             return context.makeArray(values);


### PR DESCRIPTION
- Added optional lazy-generated callers for properties on java classes or objects from JavaScript (configurable in the DatabindConfiguration).
- Fixed conversion of primitive java arrays.
- When the functional interface method returns a CompletableFuture, the current thread will not wait until the JavaScript execution finished but will give the user control over it by passing him the future about the execution, where they can add a callback to or await it themselves.
- Try to minimize native calls in conversion
- Use ArrayList to collect methods in the HeuristicMethodChooser (HashSet#add is slow)