### PR TITLE
expose GL texure id

### DIFF
--- a/ultralight-java-base/src/main/java/com/labymedia/ultralight/plugin/render/UltralightGPUDriverNative.java
+++ b/ultralight-java-base/src/main/java/com/labymedia/ultralight/plugin/render/UltralightGPUDriverNative.java
@@ -33,5 +33,7 @@ public interface UltralightGPUDriverNative {
 
     void bindTexture(long textureId, long texture);
 
+    int getGlTextureId(long texture);
+
     void setActiveWindow(long window);
 }

--- a/ultralight-java-gpu-native/include/ultralight_java/gpudriver/com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil.h
+++ b/ultralight-java-gpu-native/include/ultralight_java/gpudriver/com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil.h
@@ -79,6 +79,14 @@ JNIEXPORT void JNICALL Java_com_labymedia_ultralight_gpu_UltralightGPUDriverNati
 JNIEXPORT void JNICALL Java_com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil_bindTexture(
     JNIEnv *, jobject, jlong handle, jlong textureId, jlong texture);
 
+/*
+ * Class:     com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil
+ * Method:    getGlTextureId
+ * Signature: (JJ)I
+ */
+JNIEXPORT jint JNICALL
+Java_com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil_getGlTextureId(JNIEnv *, jobject, jlong handle, jlong texture);
+
 #    ifdef __cplusplus
 }
 #    endif

--- a/ultralight-java-gpu-native/include/ultralight_java/gpudriver/gl/GPUDriverGL.h
+++ b/ultralight-java-gpu-native/include/ultralight_java/gpudriver/gl/GPUDriverGL.h
@@ -99,6 +99,7 @@ namespace ultralight {
         virtual void DrawCommandList() override;
 
         void BindUltralightTexture(uint32_t ultralight_texture_id);
+        uint32_t GetGlTextureId(uint32_t ultralight_texture_id);
 
         void LoadPrograms();
         void DestroyPrograms();

--- a/ultralight-java-gpu-native/src/gpudriver/gl/GPUDriverGL.cpp
+++ b/ultralight-java-gpu-native/src/gpudriver/gl/GPUDriverGL.cpp
@@ -320,6 +320,12 @@ namespace ultralight {
         CHECK_GL();
     }
 
+    uint32_t GPUDriverGL::GetGlTextureId(uint32_t ultralight_texture_id) {
+        TextureEntry &entry = texture_map[ultralight_texture_id];
+        ResolveIfNeeded(entry.render_buffer_id);
+        return entry.tex_id;
+    }
+
     void GPUDriverGL::DestroyTexture(uint32_t texture_id) {
         TextureEntry &entry = texture_map[texture_id];
         glDeleteTextures(1, &entry.tex_id);

--- a/ultralight-java-gpu-native/src/gpudriver/ultralight_java_gpu.cpp
+++ b/ultralight-java-gpu-native/src/gpudriver/ultralight_java_gpu.cpp
@@ -91,3 +91,8 @@ JNIEXPORT void JNICALL Java_com_labymedia_ultralight_gpu_UltralightGPUDriverNati
     auto *driver = (ultralight::GPUDriverGL *) handle;
     driver->BindTexture(textureId, texture);
 }
+
+JNIEXPORT jint JNICALL Java_com_labymedia_ultralight_gpu_UltralightGPUDriverNativeUtil_getGlTextureId (JNIEnv *, jobject, jlong handle, jlong texture) {
+    auto *driver = (ultralight::GPUDriverGL *) handle;
+    return (jint) driver->GetGlTextureId(texture);
+}

--- a/ultralight-java-gpu/src/main/java/com/labymedia/ultralight/gpu/UltralightGPUDriverNativeUtil.java
+++ b/ultralight-java-gpu/src/main/java/com/labymedia/ultralight/gpu/UltralightGPUDriverNativeUtil.java
@@ -211,6 +211,16 @@ public class UltralightGPUDriverNativeUtil {
     public native void bindTexture(long handle, long textureId, long texture);
 
     /**
+     * Get the OpenGL texture id for a given driver-specific texture index.
+     *
+     * @param handle    OpenGL context handle
+     * @param texture   Ultralight renderTarget texture id
+     *
+     * @return          OpenGL texture id
+     */
+    public native int getGlTextureId(long handle, long texture);
+
+    /**
      * Set which GLFW context should be active.
      *
      * @param handle OpenGL context handle

--- a/ultralight-java-gpu/src/main/java/com/labymedia/ultralight/gpu/UltralightOpenGLGPUDriverNative.java
+++ b/ultralight-java-gpu/src/main/java/com/labymedia/ultralight/gpu/UltralightOpenGLGPUDriverNative.java
@@ -94,6 +94,11 @@ public class UltralightOpenGLGPUDriverNative implements UltralightGPUDriverNativ
         this.util.bindTexture(this.driverHandle, textureId, texture);
     }
 
+    @Override
+    public int getGlTextureId(long texture) {
+        return this.util.getGlTextureId(this.driverHandle, texture);
+    }
+
     /**
      * Set which GLFW context should be active.
      *


### PR DESCRIPTION
Expose the openGL texture ID in `UltralightGPUDriverNative`, so that the implementing application can then bind the texture itself, rather than delegating that to the driver.

This makes it easier to integrate with existing render engines, or engines that use texture samplers instead of direct GL textures.